### PR TITLE
Update to aws-sam-local:0.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-ENV VERSION=0.2.2
+ENV VERSION=0.2.8
 
 RUN apk add --no-cache curl && \
     curl -sSLO https://github.com/awslabs/aws-sam-local/releases/download/v${VERSION}/sam_${VERSION}_linux_386.tar.gz && \


### PR DESCRIPTION
From Bunk, an update to 0.2.8